### PR TITLE
fix UB by refactoring EmulatorState::step

### DIFF
--- a/src/emulator/ast.rs
+++ b/src/emulator/ast.rs
@@ -499,9 +499,10 @@ pub enum Operand {
 
 impl Operand {
     pub fn transform_label(self, label: &str, pc: usize) -> Self {
-        match self {
-            Operand::Label(ref l) => if l == label {Operand::Imm(pc as u64)} else {self}
-            _ => self,
+        if matches!(self, Self::Label(ref l) if l == label) {
+            Self::Imm(pc as u64)
+        } else {
+            self
         }
     }
 }

--- a/src/emulator/emulator.rs
+++ b/src/emulator/emulator.rs
@@ -1,10 +1,13 @@
-use std::{time::Duration, rc::Rc};
 use devices::DeviceHost;
+use std::{rc::Rc, time::Duration};
 
-use wasm_bindgen::prelude::*;
 use crate::emulator::ast::Parser;
+use wasm_bindgen::prelude::*;
 
-use super::{*, lexer, ast::{self, Inst, Program, Operand}};
+use super::{
+    ast::{self, Inst, Operand, Program},
+    lexer, *,
+};
 
 #[derive(Debug)]
 pub enum EmulatorErrorKind {
@@ -12,7 +15,7 @@ pub enum EmulatorErrorKind {
     StackUnderflow,
 }
 
-impl <'a> std::fmt::Display for EmulatorErrorKind {
+impl<'a> std::fmt::Display for EmulatorErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EmulatorErrorKind::StackOverflow => write!(f, "Stack overflow"),
@@ -55,13 +58,33 @@ impl Stack {
         data.resize(size, 0);
         Stack { data, sp: 0, size }
     }
-    
+
+    fn push(&mut self, data: u64) -> Result<(), EmulatorError> {
+        if self.sp < self.size as i64 {
+            self.data[self.sp as usize] = data;
+            self.sp += 1;
+            Ok(())
+        } else {
+            Err(EmulatorError(Some(EmulatorErrorKind::StackOverflow)))
+        }
+    }
+    fn pop(&mut self) -> Result<u64, EmulatorError> {
+        if self.sp > 0 {
+            self.sp -= 1;
+            Ok(self.data[self.sp as usize])
+        } else {
+            Err(EmulatorError(Some(EmulatorErrorKind::StackUnderflow)))
+        }
+    }
 }
 
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq)]
 pub enum StepResult {
-    Continue, HLT, Input, Error
+    Continue,
+    HLT,
+    Input,
+    Error,
 }
 
 pub const PC: u64 = u64::MAX;
@@ -70,80 +93,28 @@ pub const SP: u64 = u64::MAX - 1;
 fn does_overflow(a: u64, b: u64) -> bool {
     match a.checked_add(b) {
         Some(_) => false,
-        None    => true
+        None => true,
     }
 }
 
 // you cant bindgen impls i dont think
 #[wasm_bindgen]
 #[allow(dead_code)]
-impl EmulatorState  {
+impl EmulatorState {
     fn new(program: Program, devices: DeviceHost) -> Self {
         let regs = vec![0; program.headers.minreg as usize];
         let heap = vec![0; (program.headers.minheap + program.headers.minstack) as usize];
-        EmulatorState { regs, heap, stack: Stack::new(program.headers.minstack as usize), pc: 0, program, devices, error: EmulatorError::new() }
-    }
-    
-    fn get(&self, operand: &Operand) -> u64 {
-        match operand {
-            Operand::Imm(v) => *v,
-            Operand::Reg(v) => {
-                match *v {
-                    PC => self.pc as u64,
-                    SP => self.stack.data.len() as u64,
-                    _  => self.regs[*v as usize]
-                }
-            },
-            _ => panic!("Unsupported operand {:?}", operand)
+        EmulatorState {
+            regs,
+            heap,
+            stack: Stack::new(program.headers.minstack as usize),
+            pc: 0,
+            program,
+            devices,
+            error: EmulatorError::new(),
         }
-    }
-    fn set(&mut self, operand: &Operand, value: u64) {
-        match operand {
-            Operand::Imm(_) => {}, // do nothing assume it is r0
-            Operand::Reg(v) => {
-                match *v {
-                    PC => self.pc = value as usize,
-                    SP => self.stack.sp = value as i64,
-                    _  => self.regs[*v as usize] = value
-                }
-            },
-            _ => panic!("Unsupported target operand {:?}", operand)
-        }
-    }
-    
-    #[inline(always)]
-    fn get_mem(&self, index: u64) -> u64 {
-        self.heap[index as usize]
-    }
-    #[inline(always)]
-    fn set_mem(&mut self, index: u64, value: u64) {
-        self.heap[index as usize] = value
     }
 
-    fn getm(&self, operand: &Operand) -> u64 {
-        self.get_mem(self.get(operand))
-    }
-    fn setm(&mut self, operand: &Operand, value: u64) {
-        self.set_mem(self.get(operand), value)
-    }
-
-    fn stack_push(&mut self, data: u64) {
-        if self.stack.sp >= self.stack.size as i64 {
-            self.error = EmulatorError(Some(EmulatorErrorKind::StackOverflow));
-            return;
-        }
-        self.stack.data[self.stack.sp as usize] = data;
-        self.stack.sp += 1;
-    }
-    fn stack_pop(&mut self) -> Option<u64> {
-        if self.stack.sp <= 0 {
-            self.error = EmulatorError(Some(EmulatorErrorKind::StackUnderflow));
-            return None;
-        }
-        self.stack.sp -= 1;
-        Some(self.stack.data[self.stack.sp as usize])
-    }
-    
     pub fn run(&mut self) -> StepResult {
         loop {
             let result = self.step();
@@ -153,7 +124,7 @@ impl EmulatorState  {
                 _ => {
                     self.devices.show();
                     return result;
-                },
+                }
             }
         }
     }
@@ -165,7 +136,7 @@ impl EmulatorState  {
         self.devices.show();
         jsprintln!("Regs: {:?}", self.regs);
     }
-    
+
     pub fn run_for_ms(&mut self, max_time_ms: f64) -> StepResult {
         const BURST_LENGTH: u32 = 1024;
         let start = now();
@@ -179,7 +150,7 @@ impl EmulatorState  {
                     _ => {
                         self.devices.show();
                         return result;
-                    },
+                    }
                 }
             }
         }
@@ -188,264 +159,270 @@ impl EmulatorState  {
     }
     // or maybe we just run on a sepperate thread 🤔 good idea
     // lets implement that
-    
+
     // now how did multitrheading work on the web again lol
     // is there some cargo library for that or should we just do some Worker schenenigans
 
     pub fn step(&mut self) -> StepResult {
-        // safety: pc is bounds checked here 
-        if self.pc >= self.program.instructions.len() {
-            return StepResult::HLT;
-        }
-        use Inst::*;
-        // safety: pc has to bounds checked before hand
-        match unsafe{fuck_borrow_checker(self.program.instructions.get_unchecked(self.pc))} {
-            HLT => return StepResult::HLT,
-            ADD(op1, op2, op3) => {
-                self.set(op1, self.get(op2)+self.get(op3));
-            },
-            RSH(a, b) => self.set(a, self.get(b) >> 1),
-            LOD(a, b) => self.set(a, self.getm(b)),
-            STR(a, b) => self.setm(a, self.get(b)),
-            BGE(a, b, c) => {
-                if self.get(b) >= self.get(c) {
-                    self.pc = self.get(a) as usize - 1;
+        let Some(inst) = self.program.instructions.get(self.pc) else {
+            return StepResult::HLT
+        };
+
+        macro_rules! get {
+            ($operand:expr) => {
+                match $operand {
+                    Operand::Imm(v) => *v,
+                    Operand::Reg(v) => match *v {
+                        PC => self.pc as u64,
+                        SP => self.stack.data.len() as u64,
+                        _ => self.regs[*v as usize],
+                    },
+                    _ => panic!("Unsupported operand {:?}", $operand),
                 }
-            },
-            NOR(a, b, c) => self.set(a, u64::MAX - (self.get(b) | self.get(c))),
-            MOV(a, b) => self.set(a, self.get(b)),
-            INC(a, b) => self.set(a, self.get(b)+1),
-            DEC(a, b) => self.set(a, self.get(b)-1),
-            OUT(a, b) => self.devices.out(self.get(a), self.get(b)),
-            IN(_a,_b) => todo!(),
-            JMP(a) => self.pc = self.get(a) as usize - 1,
-            SUB(a, b, c) => self.set(a, self.get(b) - self.get(c)),
+            };
+        }
+        macro_rules! set {
+            ($operand:expr, $value:expr) => {
+                match $operand {
+                    Operand::Imm(_) => {} // do nothing assume it is r0
+                    Operand::Reg(v) => match *v {
+                        PC => self.pc = $value as usize,
+                        SP => self.stack.sp = $value as i64,
+                        _ => self.regs[*v as usize] = $value,
+                    },
+                    _ => panic!("Unsupported target operand {:?}", $operand),
+                }
+            };
+        }
+
+        macro_rules! get_mem {
+            ($index:expr) => {
+                self.heap[$index as usize]
+            };
+        }
+        macro_rules! set_mem {
+            ($index:expr, $value:expr) => {
+                self.heap[$index as usize] = $value
+            };
+        }
+
+        macro_rules! getm {
+            ($operand:expr) => {
+                self.heap[get!($operand) as usize]
+            };
+        }
+        macro_rules! setm {
+            ($operand:expr, $value:expr) => {
+                self.heap[get!($operand) as usize] = $value
+            };
+        }
+
+        macro_rules! insts {
+            (@pat($name:ident); $($raw:ident)*) => {
+                Inst::$name($($raw),*)
+            };
+            (@pat($name:ident) ($($($raw:ident$(: $_type_raw:ty)?)? $([$mem:ident$(: $_type_mem:ty)?])?),*)) => {
+                insts!(@pat($name); $($($raw)?)? $($($mem)?)?)
+            };
+            (@pat($name:ident)) => {
+                Inst::$name
+            };
+            (@read) => {};
+            (@read [$name:ident$(: $type:ty)?]$(, $($rest:tt)*)?) => {
+                #[allow(unused_variables)]
+                let $name = getm!($name) $(as $type)?;
+                insts!(@read $($($rest)*)?)
+            };
+            (@read $name:ident$(: $type:ty)?$(, $($rest:tt)*)?) => {
+                #[allow(unused_variables)]
+                let $name = get!($name) $(as $type)?;
+                insts!(@read $($($rest)*)?)
+            };
+            (@assign; $body:expr) => {
+                $body
+            };
+            (@assign $to:ident; $body:expr) => {{
+                let value = $body as u64;
+                set!($to, value)
+            }};
+            (@assign [$to:ident]; $body:expr) => {{
+                let value = $body as u64;
+                setm!($to, value)
+            }};
+            (
+                $($name:ident$(($($ops:tt)*))? $(; $assign:tt)? => $body:expr$(,)?)*
+            ) => {
+                match inst {
+                    $(
+
+                        insts!(@pat($name) $(($($ops)*))?) => {
+                            insts!(@assign $($assign)?; {
+                                $(insts!(@read $($ops)*);)?
+                                $body
+                            })
+                        }
+                    )*
+                }
+            };
+        }
+
+        macro_rules! branch {
+            ($dest:ident $(if $cond:expr)?) => {
+                match () {
+                    () $(if $cond)? => self.pc = $dest - 1,
+                    #[allow(unreachable_patterns)]
+                    () => (),
+                }
+            }
+        }
+
+        macro_rules! SET {
+            ($cond:expr) => {
+                if $cond {
+                    u64::MAX
+                } else {
+                    0
+                }
+            };
+        }
+
+        insts! {
             NOP => {},
-            LSH(a, b) => self.set(a, self.get(b) << 1),
-            NEG(a, b) => self.set(a, (-(self.get(b) as i64)) as u64),
-            AND(a, b, c) => self.set(a, self.get(b) & self.get(c)),
-            OR(a, b, c) => self.set(a, self.get(b) | self.get(c)),
-            NOT(a, b) => self.set(a, !self.get(b)),
-            NAND(a, b, c) => self.set(a, !(self.get(b) & self.get(c))),
-            CPY(a, b) => self.setm(a, self.getm(b)),
-            MLT(a, b, c) => self.set(a, self.get(b)*self.get(c)),
-            DIV(a, b, c) => self.set(a, self.get(b)/self.get(c)),
-            MOD(a, b, c) => self.set(a, self.get(b)%self.get(c)),
-            ABS(a, b) => self.set(a, (self.get(b) as i64).abs() as u64),
-            LLOD(a, b, c) => self.set(a, self.get_mem(self.get(b) + self.get(c))),
-            LSTR(a, b, c) => self.set_mem(self.get(a) + self.get(b), self.get(c)),
-            SDIV(a, b, c) => self.set(a, ((self.get(b) as i64)/(self.get(c) as i64)) as u64),
-            SETE(a, b, c) => self.set(a, 
-                if self.get(b) == self.get(c) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SETG(a, b, c) => self.set(a,
-                if self.get(b) > self.get(c) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SETGE(a, b, c) => self.set(a,
-                if self.get(b) >= self.get(c) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SETL(a, b, c) => self.set(a,
-                if self.get(b) < self.get(c) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SETLE(a, b, c) => self.set(a,
-                if self.get(b) <= self.get(c) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            XOR(a, b, c) => self.set(a, self.get(b)^self.get(c)),
-            XNOR(a, b, c) => self.set(a, !(self.get(b)^self.get(c))),
-            BNE(a, b, c) => {
-                if self.get(b) != self.get(c) {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            BRE(a, b, c) => {
-                if self.get(b) == self.get(c) {
-                    self.pc = self.get(a) as usize;
-                }
-            },
+            HLT => return StepResult::HLT,
+
             PSH(a) => {
-                self.stack_push(self.get(a));
-            },
-            POP(a) => {
-                match self.stack_pop() {
-                    Some(v) => self.set(a, v),
-                    None => (),
-                };
-            },
-            SSETG(a, b, c) => self.set(a,
-                if self.get(b) as i64 > self.get(c) as i64 {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SSETGE(a, b, c) => self.set(a,
-                if (self.get(b) as i64) >= (self.get(c) as i64) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SSETL(a, b, c) => self.set(a,
-                if (self.get(b) as i64) < (self.get(c) as i64) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            SSETLE(a, b, c) => self.set(a,
-                if (self.get(b) as i64) <= (self.get(c) as i64) {
-                    u64::MAX
-                } else {
-                    0
-                }
-            ),
-            BRL(a, b, c) => {
-                if self.get(b) < self.get(c) {
-                    self.pc = self.get(a) as usize - 1;
+                if let Err(err) = self.stack.push(a) {
+                    self.error = err;
                 }
             },
-            BRG(a, b, c) => {
-                if self.get(b) > self.get(c) {
-                    self.pc = self.get(a) as usize - 1;
+            POP(a); a => {
+                match self.stack.pop() {
+                    Ok(v) => v,
+                    Err(err) => {
+                        self.error = err;
+                        a
+                    },
                 }
             },
-            BLE(a, b, c) => {
-                if self.get(b) <= self.get(c) {
-                    self.pc = self.get(a) as usize - 1;
+            CAL(a: usize) => {
+                if let Err(err) = self.stack.push(self.pc as u64) {
+                    self.error = err;
                 }
+                branch!(a)
             },
-            BRZ(a, b) => {
-                if self.get(b) == 0 {
-                    self.pc = self.get(a) as usize - 1;
-                }
-            },
-            BNZ(a, b) => {
-                if self.get(b) != 0 {
-                    self.pc = self.get(a) as usize - 1;
-                }
-            },
-            SETC(a, b, c) => self.set(a, 
-                match does_overflow(self.get(b), self.get(c)) {
-                    true => u64::MAX,
-                    false => 0
-                }
-            ),
-            SETNC(a, b, c) => self.set(a, 
-                match does_overflow(self.get(b), self.get(c)) {
-                    false => u64::MAX,
-                    true => 0
-                }
-            ),
-            BNC(a, b, c) => {
-                match does_overflow(self.get(b), self.get(c)) {
-                    false => self.pc = self.get(a) as usize,
-                    _ => {}
-                }
-            },
-            BRC(a, b, c) => {
-                match does_overflow(self.get(b), self.get(c)) {
-                    true => self.pc = self.get(a) as usize,
-                    _ => {}
-                }
-            },
-            SBRL(a, b, c) => {
-                if (self.get(b) as i64) < (self.get(c) as i64) {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            SBRG(a, b, c) => {
-                if (self.get(b) as i64) > (self.get(c) as i64) {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            SBLE(a, b, c) => {
-                if (self.get(b) as i64) <= (self.get(c) as i64) {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            SBGE(a, b, c) => {
-                if (self.get(b) as i64) >= (self.get(c) as i64) {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            BOD(a, b) => {
-                if self.get(b) % 2 != 0 {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            BEV(a, b) => {
-                if self.get(b) % 2 == 0 {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            BRN(a, b) => {
-                if (self.get(b) as i64) < 0 {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            BRP(a, b) => {
-                if (self.get(b) as i64) >= 0 {
-                    self.pc = self.get(a) as usize;
-                }
-            },
-            BSR(a, b, c) => self.set(a, self.get(b)>>self.get(c)),
-            BSL(a, b, c) => self.set(a, self.get(b)>>self.get(c)),
-            SRS(a, b) => self.set(a, ((self.get(b) as i64) >> 1) as u64),
-            BSS(a, b, c) => self.set(a, ((self.get(b) as i64) >> (self.get(c) as i64)) as u64),
-            CAL(a) => {self.stack_push(self.pc as u64); self.pc = self.get(a) as usize - 1},
             RET => {
-                match self.stack_pop() {
-                    Some(v) => self.pc = v as usize,
-                    None => (),
-                };
+                match self.stack.pop().map(|v| v as usize) {
+                    Ok(v) => branch!(v),
+                    Err(err) => self.error = err,
+                }
             },
-            _ => jsprintln!("Unimplimented instruction."),
+
+            IN(a, b) => todo!(),
+            OUT(a, b) => self.devices.out(a, b),
+
+            JMP(a: usize) => branch!(a),
+            BRG(a: usize, b, c) => branch!(a if b > c),
+            BGE(a: usize, b, c) => branch!(a if b >= c),
+            BRL(a: usize, b, c) => branch!(a if b < c),
+            BLE(a: usize, b, c) => branch!(a if b <= c),
+
+            BRE(a: usize, b, c) => branch!(a if b == c),
+            BNE(a: usize, b, c) => branch!(a if b != c),
+            BRZ(a: usize, b) => branch!(a if b == 0),
+            BNZ(a: usize, b) => branch!(a if b != 0),
+            BRC(a: usize, b, c) => branch!(a if does_overflow(b, c)),
+            BNC(a: usize, b, c) => branch!(a if !does_overflow(b, c)),
+
+            SBRG(a: usize, b: i64, c: i64) => branch!(a if b > c),
+            SBGE(a: usize, b: i64, c: i64) => branch!(a if b >= c),
+            SBRL(a: usize, b: i64, c: i64) => branch!(a if b < c),
+            SBLE(a: usize, b: i64, c: i64) => branch!(a if b <= c),
+
+            BEV(a: usize, b) => branch!(a if b&1 == 0),
+            BOD(a: usize, b) => branch!(a if b&1 == 1),
+            BRP(a: usize, b: i64) => branch!(a if b >= 0),
+            BRN(a: usize, b: i64) => branch!(a if b < 0),
+
+            // semicolon exists purely to disambiguate the macro when assigning to a value
+            // square brackets are used for memory access
+            MOV(a, b); a => b,
+            STR(a, b); [b] => a,
+            CPY(a, [b]); [a] => b,
+            LOD(a, [b]); a => b,
+            LLOD(a, b, c); a => get_mem!(b + c),
+            LSTR(a, b, c) => set_mem!(a + b, c),
+
+            ADD(a, b, c); a => b + c,
+            SUB(a, b, c); a => b - c,
+            INC(a, b); a => b + 1,
+            DEC(a, b); a => b - 1,
+
+            RSH(a, b); a => b >> 1,
+            LSH(a, b); a => b << 1,
+            SRS(a, b: i64); a => b >> 1,
+
+            BSR(a, b, c); a => b >> c,
+            BSL(a, b, c); a => b << c,
+            BSS(a, b: i64, c: i64); a => b >> c,
+
+            OR(a, b, c); a => b | c,
+            NOR(a, b, c); a => !(b | c),
+            AND(a, b, c); a => b & c,
+            NAND(a, b, c); a => !(b & c),
+            XOR(a, b, c); a => b ^ c,
+            XNOR(a, b, c); a => !(b ^ c),
+
+            NOT(a, b); a => !b,
+            NEG(a, b: i64); a => -b,
+            ABS(a, b: i64); a => b.abs(),
+
+            MLT(a, b, c); a => b * c,
+            DIV(a, b, c); a => b / c,
+            SDIV(a, b: i64, c: i64); a => b / c,
+            MOD(a, b, c); a => b % c,
+
+            SETE(a, b, c); a => SET!(b == c),
+            SETNE(a, b, c); a => SET!(b != c),
+            SETC(a, b, c); a => SET!(does_overflow(b, c)),
+            SETNC(a, b, c); a => SET!(!does_overflow(b, c)),
+
+            SETG(a, b, c); a => SET!(b > c),
+            SETGE(a, b, c); a => SET!(b >= c),
+            SETL(a, b, c); a => SET!(b < c),
+            SETLE(a, b, c); a => SET!(b <= c),
+            SSETG(a, b: i64, c: i64); a => SET!(b > c),
+            SSETGE(a, b: i64, c: i64); a => SET!(b >= c),
+            SSETL(a, b: i64, c: i64); a => SET!(b < c),
+            SSETLE(a, b: i64, c: i64); a => SET!(b <= c),
         }
+
         self.pc += 1;
 
         match &self.error {
             EmulatorError(Some(err)) => {
-                jsprintln!("<span class=\"error\">Emulator Error: {} at PC: {}</span>", err, self.pc-1);
+                jsprintln!(
+                    "<span class=\"error\">Emulator Error: {} at PC: {}</span>",
+                    err,
+                    self.pc - 1
+                );
                 StepResult::Error
-            },
-            EmulatorError(None) => StepResult::Continue
+            }
+            EmulatorError(None) => StepResult::Continue,
         }
     }
 }
 
-#[inline]
-unsafe fn fuck_borrow_checker<T>(a: *const T) -> &'static T { // no 
-    &*a
-}
-
 #[allow(dead_code)]
 #[wasm_bindgen]
-pub fn emulate(src: String) -> Option<EmulatorState> { // wifi died
+pub fn emulate(src: String) -> Option<EmulatorState> {
+    // wifi died
     let src = Rc::from(src);
     clear_text();
     let toks = lexer::lex(&src);
 
-    let Parser {ast: program, err, ..} = ast::gen_ast(toks, src.clone());
+    let Parser {
+        ast: program, err, ..
+    } = ast::gen_ast(toks, src.clone());
     jsprintln!("{:#?}", program);
     jsprintln!("{}", err.to_string(&src));
     if err.has_error() {


### PR DESCRIPTION
``EmualtorState::step`` previously called ``fuck_the_borrow_checker`` with unsafe code that causes Undefined Behaviour. i've refactored it to no longer borrow ``self``, only fields of ``self``, so the value returned by ``self.program.instructions.get()`` can now be used, while avoiding any cloning that may be expensive.